### PR TITLE
🐛 DXP-26: Fix log preview showing files but download claiming no logs

### DIFF
--- a/lib/tools/log-download-tools.js
+++ b/lib/tools/log-download-tools.js
@@ -1781,8 +1781,10 @@ class LogDownloadTools {
                         const isShowingPreview = !args.skipConfirmation && !args.force;
                         let quickCheckLimit = null;
 
-                        // Apply limit for preview OR when we're going to show a preview (not direct download)
-                        if ((isPreviewMode || isShowingPreview) && dateFilter && dateFilter.startDate && dateFilter.endDate) {
+                        // DXP-26 FIX: Only apply limit for preview mode, NOT when actually downloading
+                        // The issue was that preview with limit found files but actual download re-scanned
+                        // with different timing and found no files
+                        if (isPreviewMode && dateFilter && dateFilter.startDate && dateFilter.endDate) {
                             // Calculate time range in hours
                             const rangeMs = dateFilter.endDate.getTime() - dateFilter.startDate.getTime();
                             const rangeHours = rangeMs / (1000 * 60 * 60);
@@ -1800,6 +1802,8 @@ class LogDownloadTools {
                             if (process.env.DEBUG === 'true') {
                                 console.error(`[PREVIEW OPTIMIZATION] Time range: ${rangeHours.toFixed(1)} hours, checking first ${quickCheckLimit} files in ${containerName}`);
                             }
+                        } else if (!isPreviewMode && process.env.DEBUG === 'true') {
+                            console.error(`[DXP-26 FIX] Download mode - fetching ALL logs without limit for ${containerName}`);
                         }
 
                         const logs = await this.listLogs(sasUrl, dateFilter, containerName, quickCheckLimit);
@@ -1807,18 +1811,16 @@ class LogDownloadTools {
                             // Calculate total size for this container
                             const totalSize = logs.reduce((sum, log) => sum + (log.size || 0), 0);
 
-                            // CRITICAL FIX: For download phase, we need ALL logs, not just the preview subset
-                            // Store both limited logs for preview AND fetch full logs for download
+                            // DXP-26 FIX: Store the logs for later use in download
+                            // When in preview mode, we show limited logs but store the fact we need to refetch
+                            // When in download mode (skipConfirmation=true), we already have ALL logs
                             let allLogsForDownload = logs;
+                            let needsRefetch = false;
                             if (quickCheckLimit && logs.length >= quickCheckLimit) {
-                                // We hit the limit, so there are likely more files
-                                // For download, we need to fetch ALL logs without the limit
+                                // We hit the limit in preview, mark that we need to refetch for download
+                                needsRefetch = true;
                                 if (process.env.DEBUG === 'true') {
-                                    console.error(`[DOWNLOAD FIX] Preview found ${logs.length} files (limit: ${quickCheckLimit}), fetching ALL files for download...`);
-                                }
-                                allLogsForDownload = await this.listLogs(sasUrl, dateFilter, containerName, null);
-                                if (process.env.DEBUG === 'true') {
-                                    console.error(`[DOWNLOAD FIX] Full scan found ${allLogsForDownload.length} files (was ${logs.length} in preview)`);
+                                    console.error(`[DXP-26] Preview hit limit (${logs.length}/${quickCheckLimit}), will need full fetch for download`);
                                 }
                             }
 
@@ -1829,7 +1831,8 @@ class LogDownloadTools {
                                 totalSize: totalSize,
                                 logs: allLogsForDownload,  // Store ALL logs for download
                                 sasUrl: sasUrl,  // Store SAS URL to avoid regenerating
-                                dateFilter: dateFilter  // Store date filter for consistency
+                                dateFilter: dateFilter,  // Store date filter for consistency
+                                needsRefetch: needsRefetch  // DXP-26: Flag if we need to refetch for download
                             };
 
                             if (process.env.DEBUG === 'true') {
@@ -2072,7 +2075,18 @@ class LogDownloadTools {
             
             // Use containersWithLogs which already has all the data we need
             for (const container of containersWithLogs) {
-                const { logType, containerName, logs, sasUrl, dateFilter } = container;
+                let { logType, containerName, logs, sasUrl, dateFilter, needsRefetch } = container;
+
+                // DXP-26 FIX: If we need to refetch (preview hit limit), do it now
+                if (needsRefetch && sasUrl && dateFilter) {
+                    if (process.env.DEBUG === 'true') {
+                        console.error(`[DXP-26] Refetching ALL logs for ${containerName} (preview was limited)...`);
+                    }
+                    logs = await this.listLogs(sasUrl, dateFilter, containerName, null);
+                    if (process.env.DEBUG === 'true') {
+                        console.error(`[DXP-26] Full fetch found ${logs.length} files for ${containerName}`);
+                    }
+                }
                 // Show what's being downloaded and where
                 const containerSubfolder = this.getContainerSubfolderName(containerName);
                 // Use DownloadConfig to respect project logPath settings


### PR DESCRIPTION
## Summary
Fixes issue where log preview shows available files but the actual download claims there are no logs to download.

## The Problem
In the `handleDownloadAllLogs` function:
1. Preview mode used a `quickCheckLimit` to show a subset of logs for performance
2. When `skipConfirmation=true` was passed for actual download, it re-scanned containers from scratch
3. The re-scan would sometimes find no logs due to timing differences or different query limits

## The Fix
- Only apply `quickCheckLimit` in preview mode (`previewOnly=true`), not when showing preview before download
- Store a `needsRefetch` flag when preview hits the limit
- When downloading after preview, if `needsRefetch` is true, fetch ALL logs without limit
- This ensures consistency between what the preview shows and what actually gets downloaded

## Test Plan
- [ ] Test `download all logs` with preview first, then confirm download
- [ ] Verify preview shows files and download actually downloads them
- [ ] Test with time-limited queries (e.g., `hoursBack: 4`)
- [ ] Verify fix works for both single container and "all" downloads

Fixes #DXP-26

🤖 Generated with [Claude Code](https://claude.ai/code)